### PR TITLE
Default data.body.value to {}

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -329,8 +329,9 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
      */
     determineMetadata(data) {
         const metadata = data.requestData.desiredCapabilities.metadata;
-        const currentBrowserName = data.body.value.browserName;
-        const currentBrowserVersion = data.body.value.version || data.body.value.browserVersion;
+        const bodyValue = data.body.value || {};
+        const currentBrowserName = bodyValue.browserName || NOT_KNOWN;
+        const currentBrowserVersion = bodyValue.version || bodyValue.browserVersion || NOT_KNOWN;
         const browser = {
             name: metadata && metadata.browser && metadata.browser.name ? metadata.browser.name : currentBrowserName,
             version: metadata && metadata.browser && metadata.browser.version ? metadata.browser.version : currentBrowserVersion,


### PR DESCRIPTION
In certain situations, `data.body.value` is undefined when the reporter
runs. Defaulting to {} and allowing to fall through to either
user-defined metadata or NOT_KNOWN.