### PR TITLE
feat: add embeddings to the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ This reporter does two things
 
 ![Snapshot - Given When Then Datatables](./docs/assets/given-datatables.jpg)
 
+4. Data can also be added to steps with the following code
+
+
+```js
+import multipleCucumberHtmlReporter from 'wdio-multiple-cucumber-html-reporter';
+
+// Attach a string
+multipleCucumberHtmlReporter.attach('just a string');
+// Attach JSON
+multipleCucumberHtmlReporter.attach({"json-string": true}, 'application/json');
+// Attach a screenshot
+multipleCucumberHtmlReporter.attach(browser.saveScreenshot(), 'image/png');
+// Or with
+multipleCucumberHtmlReporter.attach(browser.screenshot(), 'image/png');
+```
+
 > Not all options / data that is provided in [multiple-cucumber-html-reporter](https://github.com/wswebcreation/multiple-cucumber-html-reporter) can be used due to limitations in the generated JSON file by this reporter
 
 
@@ -249,12 +265,15 @@ Just create a `After`-hook in a stepfile like this
 
 ```js
 const {After, Status} = require('cucumber');
+import multipleCucumberHtmlReporter from 'wdio-multiple-cucumber-html-reporter';
 
 After((scenarioResult)=>{
     // Here it is added to a failed step, but each time you call `browser.saveScreenshot()` it will automatically bee added to the report
     if (scenarioResult.result.status === Status.FAILED) {
         // It will add the screenshot to the JSON
-        browser.saveScreenshot()
+        multipleCucumberHtmlReporter.attach(browser.saveScreenshot(), 'image/png');
+        // Or with
+        multipleCucumberHtmlReporter.attach(browser.screenshot(), 'image/png');
     }
     return scenarioResult.status;
 });

--- a/__tests__/features/attach.feature
+++ b/__tests__/features/attach.feature
@@ -1,0 +1,7 @@
+#@wip
+Feature: Example
+
+    Scenario: example attatch
+        Given I open the url "http://127.0.0.1:8080/"
+        When I'm a scenario when step
+        Then I'm a scenario then step

--- a/__tests__/step_definitions/all.steps.js
+++ b/__tests__/step_definitions/all.steps.js
@@ -1,4 +1,5 @@
 import { After, Before, Given, Status, Then, When } from 'cucumber';
+import multipleCucumberHtmlReporter from'../../build/reporter';
 
 Given(/I open "(.*)"/, function (url) {
     browser.url(url);
@@ -87,6 +88,17 @@ When(/I'm a scenario when step/, () => {});
 Then(/I would be a when background/, () => {});
 Then(/I'm a scenario then step/, () => {});
 
+
+/**
+ * For the attach
+ */
+Given(/I open the url "(.*)"/, url => {
+    browser.url(url)
+    multipleCucumberHtmlReporter.attach('just a string');
+    multipleCucumberHtmlReporter.attach({"json-string": true}, 'application/json');
+    multipleCucumberHtmlReporter.attach(browser.saveScreenshot(), 'image/png');
+    multipleCucumberHtmlReporter.attach(browser.screenshot(), 'image/png');
+});
 
 /**
  * For the app

--- a/lib/generateJson.js
+++ b/lib/generateJson.js
@@ -19,7 +19,7 @@ export function generateJson(folder, data) {
         });
         // Delete temporary data
         delete val._elements;
-        delete val._screenshots;
+        delete val._attachment;
         json.push(val)
     });
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,4 +1,5 @@
-import events from 'events'
+import events from 'events';
+import process from 'process';
 import { removeSync } from 'fs-extra';
 import { generateJson } from './generateJson';
 import { generate } from 'multiple-cucumber-html-reporter';
@@ -36,7 +37,7 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
 
         // Test framework events
         this.on('suite:start', ::this.suiteStart);
-        this.on('suite:end', ::this.suiteEnd);
+        // this.on('suite:end', ::this.suiteEnd);
         this.on('test:start', ::this.testStart);
         this.on('test:pass', ::this.testPass);
         this.on('test:fail', ::this.testFail);
@@ -47,6 +48,9 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
         // this.on('runner:command', ::this.runnerCommand);
         this.on('runner:result', ::this.runnerResult);
         this.on('end', ::this.onEnd);
+
+        // Multiple Cucumber HTML events
+        this.on('mchr:attachment', ::this.mchrAttachment)
     }
 
     onStart() {
@@ -67,10 +71,7 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
         this.scenarioName = suite.title;
     }
 
-    suiteEnd(suite) {
-        // Attach an Afterhook if there are embeddings
-        this.addAfterStep(suite);
-    }
+    // suiteEnd(suite) {}
 
     testStart(test) {
         if (!this.results[ test.cid ]._elements[ test.parent ]) {
@@ -101,9 +102,6 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
         if (!this.instanceData[ cid ]) {
             this.instanceData[ cid ] = this.determineMetadata(result);
         }
-
-        // attach the screenshot to the report
-        this.attachScreenshot(result);
     }
 
     onEnd(payload) {
@@ -151,7 +149,7 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
      *      _elements: {object},
      *      elements: Array,
      *      id: string,
-     *      _screenshots: Array
+     *      _attachment: Array
      *  }
      * }
      */
@@ -166,7 +164,7 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
             _elements: {},  // Temporary. All data will be copied to the `elements` when done
             elements: [],
             id: featureData.title.replace(/ /g, '-').toLowerCase(),
-            _screenshots: [], // Temporary, screenshots will be added here and removed per step...
+            _attachment: [], // Temporary, attachments will be added here and removed per step...
             ...this.instanceData[ featureData.cid ],
         }
     }
@@ -226,44 +224,7 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
             }
         ;
 
-        // Empty the _screenshots because there is no data anymore, test has finished
-        this.results[ stepData.cid ]._screenshots = [];
-
         return stepResult;
-    }
-
-    /**
-     * Add the after step, if there is data, to the steps in the suites report
-     *
-     * @param {object} currentScenario the suite we are currently running
-     */
-    addAfterStep(currentScenario) {
-        if (this.results[ currentScenario.cid ]._screenshots.length > 0 &&
-            (
-                this.results[ currentScenario.cid ]._elements[ currentScenario.uid ] &&
-                this.results[ currentScenario.cid ]._elements[ currentScenario.uid ].steps
-            )
-        ) {
-            // Add an After step if there are screenshots and there is a steps array defined on the scenario.
-            // Defaulted most of the values because they are not available in webdriverio
-            this.results[ currentScenario.cid ]._elements[ currentScenario.uid ].steps.push({
-                arguments: [],
-                keyword: 'After',
-                result: {
-                    status: 'passed',
-                    duration: 0
-                },
-                hidden: true,
-                // Add the screenshot embeddings if there are screenshots
-                ...this.defineEmbeddings(currentScenario.cid),
-                match: {
-                    location: 'can not be determined with webdriver.io'
-                }
-            });
-        }
-
-        // Empty the _screenshots because there is no data anymore, test has finished
-        this.results[ currentScenario.cid ]._screenshots = [];
     }
 
     /**
@@ -277,13 +238,14 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
      * }
      */
     defineEmbeddings(cid) {
-        return {
-            // Add the screenshot embeddings if there are screenshots
-            ...(this.results[ cid ]._screenshots.length > 0
-                    ? { embeddings: [ ...this.results[ cid ]._screenshots ] }
-                    : {}
-            ),
-        };
+        const embeddings = this.results[ cid ]._attachment.length > 0
+            ? { embeddings: [ ...this.results[ cid ]._attachment ] }
+            : {};
+
+        // Empty the attachments because there is no data anymore, step has finished
+        this.results[ cid ]._attachment = [];
+
+        return embeddings;
     }
 
     /**
@@ -402,12 +364,6 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
      * @param {object} data Instance data
      */
     attachScreenshot(data) {
-        if (data.requestOptions.uri.path.match(/\/session\/[^/]*\/screenshot/) && data.body.value) {
-            this.results[ data.cid ]._screenshots.push({
-                data: data.body.value,
-                mime_type: 'image/png',
-            });
-        }
     }
 
     /**
@@ -418,6 +374,30 @@ class MultipleCucumberHtmlReporter extends events.EventEmitter {
      */
     escapeHTML(string) {
         return !string ? string : string.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\"/g, '&quot;').replace(/\'/g, '&#39;');
+    }
+
+    /**
+     * Attach data to the report
+     *
+     * @param {string|object} data
+     * @param {string} type Default is `text/plain`, otherwise what people deliver as a MIME type, like `application/json`, `image/png`
+     */
+    static attach(data, type = 'text/plain') {
+        process.send({ event: 'mchr:attachment', ...{ data, type } })
+    }
+
+    /**
+     * Add the attachment to the result
+     *
+     * @param {string} cid
+     * @param {string|object} data
+     * @param {string} type
+     */
+    mchrAttachment({ cid, data, type }) {
+        this.results[ cid ]._attachment.push({
+            data: data,
+            mime_type: type,
+        });
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3646,7 +3646,7 @@
         },
         "npm-install-package": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
             "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
             "dev": true
         },


### PR DESCRIPTION
This PR fixes https://github.com/wswebcreation/wdio-multiple-cucumber-html-reporter/issues/18

**Comments:**
- add attach method
- remove addAfterStep to add screenshots on failure
- update docs

BREAKING: this change is breaking because users now need to use the following

```js
import multipleCucumberHtmlReporter from 'wdio-multiple-cucumber-html-reporter';

// Attach a string
multipleCucumberHtmlReporter.attach('just a string');
// Attach JSON
multipleCucumberHtmlReporter.attach({"json-string": true}, 'application/json');
// Attach a screenshot
multipleCucumberHtmlReporter.attach(browser.saveScreenshot(), 'image/png');
// Or with
multipleCucumberHtmlReporter.attach(browser.screenshot(), 'image/png');
```